### PR TITLE
added explicit disconnect as well as table reuse

### DIFF
--- a/haricot.lua
+++ b/haricot.lua
@@ -94,9 +94,21 @@ end
 -- connection
 
 local connect = function(self, server, port)
+  if self.cnx ~= nil then self:disconnect() end
   self.cnx = socket.tcp()
-  self.cnx:connect(server, port)
+  local co, err = self.cnx:connect(server,port)
+  if co == nil then return false, err end
   return true
+end
+
+local disconnect = function(self)
+  if self.cnx ~= nil then
+    self:quit()
+    self.cnx:close()
+    self.cnx = nil
+    return true
+  end
+  return false, "NOT_CONNECTED"
 end
 
 -- producer
@@ -284,7 +296,9 @@ end
 
 local methods = {
   -- connection
-  connect = connect, -- (server,port) -> ok
+  connect = connect, -- (server,port) -> ok,[err]
+  disconnect = disconnect, -- () -> ok,[err]
+
   -- producer
   put = put, -- (pri,delay,ttr,data) -> ok,[id|err]
   use = use, -- (tube) -> ok,[err]
@@ -323,3 +337,6 @@ end
 return {
   new = new,
 }
+
+-- vim: set tabstop=2 softtabstop=2 shiftwidth=2 expandtab : --
+


### PR DESCRIPTION
When using haricot with [wsapi](https://github.com/keplerproject/wsapi) open sockets can hang around for a while until garbage collection closes them. One can issue 'quit' to cause beanstalkd to close an accepted socket however the local end still consumes resources until garbage collection.

This patch adds an explicit 'disconnect' function which will terminate protocol communication via a 'quit' message and then close the socket. The 'connect' function has also been modified to promote reuse of a haricot table instance when connecting to multiple servers.

Some notes for anyone that intends to use 'disconnect' or reuse via 'connect':
- [luasocket](http://w3.impa.br/~diego/software/luasocket/home.html) hides socket close failures such as EBADF so I assume here that the close was successful.
- reusing connect may give you hostname resolution failures where the initial 'new' call may have hidden them.
